### PR TITLE
Load env

### DIFF
--- a/scripts/bosh-login.sh
+++ b/scripts/bosh-login.sh
@@ -1,12 +1,6 @@
 #!/bin/bash
 
-if [[ "$FOUNDATION" != "" ]]; then
-  echo "sourcing $PWD/scripts/$FOUNDATION-env...."
-  source $PWD/scripts/$FOUNDATION-env
-else
-  echo "sourcing $PWD/env...."
-  source $PWD/scripts/env
-fi
+source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/load-env.sh
 
 export BOSH_CLIENT=admin
 export BOSH_CLIENT_SECRET=`$BOSH_CMD int $PWD/$BOSH_ALIAS/creds.yml --path /admin_password`

--- a/scripts/credhub-login.sh
+++ b/scripts/credhub-login.sh
@@ -1,12 +1,6 @@
 #!/bin/bash
 
-if [[ "$FOUNDATION" != "" ]]; then
-  echo "sourcing $PWD/scripts/$FOUNDATION-env...."
-  source $PWD/scripts/$FOUNDATION-env
-else
-  echo "sourcing $PWD/env...."
-  source $PWD/scripts/env
-fi
+source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/load-env.sh
 
 export CREDHUB_CLIENT=concourse_to_credhub
 export CREDHUB_SECRET=$(bosh int $PWD/$BOSH_ALIAS/concourse-vars.yml --path /concourse_to_credhub_secret)

--- a/scripts/delete.sh
+++ b/scripts/delete.sh
@@ -1,12 +1,7 @@
 #!/bin/bash -e
 
-if [[ "$FOUNDATION" != "" ]]; then
-  echo "sourcing $PWD/scripts/$FOUNDATION-env...."
-  source $PWD/scripts/$FOUNDATION-env
-else
-  echo "sourcing $PWD/env...."
-  source $PWD/scripts/env
-fi
+source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/load-env.sh
+source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/releases
 
 export BOSH_CLIENT=admin
 export BOSH_CLIENT_SECRET=`$BOSH_CMD int $PWD/$BOSH_ALIAS/creds.yml --path /admin_password`

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,12 +1,7 @@
 #!/bin/bash -e
 
-if [[ "$FOUNDATION" != "" ]]; then
-  echo "sourcing $PWD/scripts/$FOUNDATION-env...."
-  source $PWD/scripts/$FOUNDATION-env
-else
-  echo "sourcing $PWD/env...."
-  source $PWD/scripts/env
-fi
+source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/load-env.sh
+source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/releases
 
 mkdir -p $BOSH_ALIAS
 

--- a/scripts/deploy_credhub.sh
+++ b/scripts/deploy_credhub.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/load-env.sh
+source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/releases
+
 $BOSH_CMD -e $BOSH_ALIAS -n upload-release $UAA_RELEASE_URL
 
 $BOSH_CMD -e $BOSH_ALIAS -n upload-release $CREDHUB_RELEASE_URL

--- a/scripts/deploy_vault.sh
+++ b/scripts/deploy_vault.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/load-env.sh
+source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/releases
+
 $BOSH_CMD -e $BOSH_ALIAS -n upload-release $CONSUL_RELEASE_URL
 
 $BOSH_CMD -e $BOSH_ALIAS -n upload-release $VAULT_RELEASE_URL

--- a/scripts/env
+++ b/scripts/env
@@ -1,14 +1,11 @@
 #!/bin/bash
 
-BOSH_CMD=bosh
-VAULT_CMD=vault
-JQ_CMD=jq
-CREDHUB_CMD=credhub
-export PWD=$(pwd)
+###
+# Export the `FOUNDATION` environment variable.
+# Copy this file as $FOUNDATION-env.
+# When running scripts in this directory will load the $FOUNDATION-env instead of this file.
+##
 
-source $PWD/scripts/releases
-
-##### START FILLING FROM HERE #####
 export CONCOURSE_RELEASES_LATEST=true
 
 export BOSH_ALIAS=concourse-bosh
@@ -82,21 +79,7 @@ export TLS_BIND_PORT=443
 export RESERVED_IPS="[\"172.16.0.0-172.16.1.30\"]"
 export CLOUD_CONFIG_STATIC_IPS=172.16.1.32-172.16.1.41 # Block all the static IP's used here in this deployment
 
-UNAME=$(uname)
-if [[ "$UNAME" == "Darwin" && "$CREDENTIAL_MANAGER" == "vault" ]]; then
-  networksetup -setdnsservers Wi-Fi $DNS_SERVERS
-fi
-
 export HTTP_PROXY_REQUIRED=false # true or false
 export HTTP_PROXY=
 export HTTPS_PROXY=
 export NO_PROXY_PATTERN='10.198.159.{0..127}'
-
-export http_proxy=$HTTP_PROXY
-export https_proxy=$HTTPS_PROXY
-
-if [[ "$HTTP_PROXY_REQUIRED" == "true" ]]; then
-  printf -v NO_PROXY '%s,' $(eval echo $NO_PROXY_PATTERN)
-  export NO_PROXY
-  export no_proxy=$NO_PROXY
-fi

--- a/scripts/load-env.sh
+++ b/scripts/load-env.sh
@@ -9,7 +9,7 @@
 #   source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/load-env.sh
 ##
 
-declare -r __BASEDIR__="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+__BASEDIR__="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
 export BOSH_CMD=bosh
 export VAULT_CMD=vault

--- a/scripts/load-env.sh
+++ b/scripts/load-env.sh
@@ -1,0 +1,41 @@
+#!/bin/bash -e
+
+###
+# Description:
+#   Loads the environment based on the `FOUNDATION` environment variable;
+#     otherwise, loads the env file
+#
+# Usage:
+#   source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/load-env.sh
+##
+
+declare -r __BASEDIR__="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+
+export BOSH_CMD=bosh
+export VAULT_CMD=vault
+export JQ_CMD=jq
+export CREDHUB_CMD=credhub
+
+if [[ "$FOUNDATION" != "" ]]; then
+  echo "sourcing $__BASEDIR__/scripts/$FOUNDATION-env...."
+  source "$__BASEDIR__"/scripts/$FOUNDATION-env
+else
+  echo "sourcing $__BASEDIR__/env...."
+  source "$__BASEDIR__"/scripts/env
+fi
+
+source "$__BASEDIR__"/releases
+
+UNAME=$(uname)
+if [[ "$UNAME" == "Darwin" && "$CREDENTIAL_MANAGER" == "vault" ]]; then
+  networksetup -setdnsservers Wi-Fi $DNS_SERVERS
+fi
+
+export http_proxy=$HTTP_PROXY
+export https_proxy=$HTTPS_PROXY
+
+if [[ "$HTTP_PROXY_REQUIRED" == "true" ]]; then
+  printf -v NO_PROXY '%s,' $(eval echo $NO_PROXY_PATTERN)
+  export NO_PROXY
+  export no_proxy=$NO_PROXY
+fi

--- a/scripts/load-env.sh
+++ b/scripts/load-env.sh
@@ -24,8 +24,6 @@ else
   source "$__BASEDIR__"/scripts/env
 fi
 
-source "$__BASEDIR__"/releases
-
 UNAME=$(uname)
 if [[ "$UNAME" == "Darwin" && "$CREDENTIAL_MANAGER" == "vault" ]]; then
   networksetup -setdnsservers Wi-Fi $DNS_SERVERS

--- a/scripts/vault-login.sh
+++ b/scripts/vault-login.sh
@@ -1,12 +1,6 @@
 #!/bin/bash
 
-if [[ "$FOUNDATION" != "" ]]; then
-  echo "sourcing $PWD/scripts/$FOUNDATION-env...."
-  source $PWD/scripts/$FOUNDATION-env
-else
-  echo "sourcing $PWD/env...."
-  source $PWD/scripts/env
-fi
+source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/load-env.sh
 
 export VAULT_TOKEN=$(cat $PWD/$BOSH_ALIAS/vault.log | grep 'Initial Root Token' | awk '{print $4}')
 $VAULT_CMD login $VAULT_TOKEN

--- a/scripts/vault-unseal.sh
+++ b/scripts/vault-unseal.sh
@@ -1,12 +1,6 @@
 #!/bin/bash
 
-if [[ "$FOUNDATION" != "" ]]; then
-  echo "sourcing $PWD/scripts/$FOUNDATION-env...."
-  source $PWD/scripts/$FOUNDATION-env
-else
-  echo "sourcing $PWD/env...."
-  source $PWD/scripts/env
-fi
+source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/load-env.sh
 
 export VAULT_ADDR=$1
 


### PR DESCRIPTION
Changes
=======
* Moves non-configurations from the env and places them in a `load-env.sh` script to avoid copying code from one foundation env to the next.
* Moves the logic behind loading the `$FOUNDATION-env` to the `load-env.sh` script for easier usage in other scripts.
* Moves the `releases` loading out of the env and only into the scripts that need them.

Finding `releases` dependents
=======================
To find the scripts that needed the `releases` script sourced, the following command was run:
```
for var in $(grep 'export' scripts/releases | awk '{print $2}' | awk -F= '{print $1}'); do grep -Rl --exclude=./scripts/releases $var . ; done | sort | uniq
```

Output:
```
./scripts/delete.sh
./scripts/deploy.sh
./scripts/deploy_credhub.sh
./scripts/deploy_vault.sh
```