### PR TITLE
Ops Files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,18 +4,19 @@
 
 FROM ubuntu:latest
 
-RUN apt-get update
-RUN apt-get install -y \
-  jq \
-  man \
-  git \
-  vim \
-  curl \
-  wget \
-  unzip \
-  direnv \
-  supervisor
-RUN rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+  && apt-get install -y \
+    jq \
+    man \
+    git \
+    vim \
+    curl \
+    wget \
+    nmap \
+    unzip \
+    direnv \
+    supervisor \
+  && rm -rf /var/lib/apt/lists/*
 
 RUN curl \
   -o /usr/local/bin/bosh \

--- a/scripts/bosh/bosh-create-env.sh
+++ b/scripts/bosh/bosh-create-env.sh
@@ -6,7 +6,6 @@ source "$__DIR__"/../helpers
 source "$__DIR__"/../load-env
 source "$__DIR__"/../releases bosh uaa stemcell vsphere_cpi os_conf
 
-
 BOSH_DEPLOYMENT_DIRECTORY="$( git_submodule bosh-deployment )"
 
 HTTP_PROXY_OPS_FILES=" "
@@ -23,6 +22,17 @@ RESOURCE_POOL_VARS=" "
 if [ -n "$VCENTER_RESOURCE_POOL" ]; then
   RESOURCE_POOL_OPS_FILE=" -o \"$BOSH_DEPLOYMENT_DIRECTORY\"/vsphere/resource-pool.yml"
   RESOURCE_POOL_VARS=" -v vcenter_rp=\"$VCENTER_RESOURCE_POOL\""
+fi
+
+CONFIG_SERVER_OPS_FILE=" "
+CONFIG_SERVER_VARS=" "
+if [ -n "$CONFIG_SERVER" ]; then
+  if [ "$CONFIG_SERVER" = "credhub" ]; then
+    CONFIG_SERVER_OPS_FILE=" -o \"$BOSH_DEPLOYMENT_DIRECTORY\"/credhub.yml"
+    CONFIG_SERVER_VARS=" "
+  else
+    log "Unknown config server configuration"
+  fi
 fi
 
 log "Creating bosh environment"
@@ -63,6 +73,7 @@ $BOSH_CMD \
     -v uaa_release_sha="$UAA_RELEASE_SHA" \
     --var-file trusted_certs="$TRUSTED_CERT_FILE" \
     $RESOURCE_POOL_OPS_FILE $RESOURCE_POOL_VARS \
-    $HTTP_PROXY_OPS_FILES $HTTP_PROXY_VARS
+    $HTTP_PROXY_OPS_FILES $HTTP_PROXY_VARS \
+    $CONFIG_SERVER_OPS_FILE $CONFIG_SERVER_VARS
 
 # creates bosh env

--- a/scripts/bosh/bosh-create-env.sh
+++ b/scripts/bosh/bosh-create-env.sh
@@ -1,0 +1,68 @@
+#!/bin/bash -e
+
+declare -r __DIR__="$( dirname "$( readlink -f "${BASH_SOURCE[0]}" )" )"
+
+source "$__DIR__"/../helpers
+source "$__DIR__"/../load-env
+source "$__DIR__"/../releases bosh uaa stemcell vsphere_cpi os_conf
+
+
+BOSH_DEPLOYMENT_DIRECTORY="$( git_submodule bosh-deployment )"
+
+HTTP_PROXY_OPS_FILES=" "
+HTTP_PROXY_VARS=" "
+if [ "$HTTP_PROXY_REQUIRED" = "true" ]; then
+  HTTP_PROXY_OPS_FILES=" -o $BOSH_DEPLOYMENT_DIRECTORY/misc/proxy.yml "
+  HTTP_PROXY_VARS=" -v http_proxy=$HTTP_PROXY \
+        -v https_proxy=$HTTPS_PROXY \
+        -v no_proxy=$NO_PROXY "
+fi
+
+RESOURCE_POOL_OPS_FILE=" "
+RESOURCE_POOL_VARS=" "
+if [ -n "$VCENTER_RESOURCE_POOL" ]; then
+  RESOURCE_POOL_OPS_FILE=" -o \"$BOSH_DEPLOYMENT_DIRECTORY\"/vsphere/resource-pool.yml"
+  RESOURCE_POOL_VARS=" -v vcenter_rp=\"$VCENTER_RESOURCE_POOL\""
+fi
+
+log "Creating bosh environment"
+$BOSH_CMD \
+  create-env "$BOSH_DEPLOYMENT_DIRECTORY"/bosh.yml \
+    --state="$ALIAS_DIRECTORY"/state.json \
+    --vars-store="$ALIAS_DIRECTORY"/creds.yml \
+    -o "$BOSH_DEPLOYMENT_DIRECTORY"/vsphere/cpi.yml \
+    -o "$BOSH_DEPLOYMENT_DIRECTORY"/jumpbox-user.yml \
+    -o "$BOSH_DEPLOYMENT_DIRECTORY"/uaa.yml \
+    -o "$__BASEDIR__"/ops-files/versions.yml \
+    -o "$__BASEDIR__"/ops-files/dns.yml \
+    -o "$__BASEDIR__"/ops-files/director-trusted-certs.yml \
+    -v director_name="$BOSH_ALIAS" \
+    -v internal_cidr="$NETWORK_CIDR" \
+    -v internal_gw="$NETWORK_GATEWAY" \
+    -v internal_ip="$BOSH_IP" \
+    -v dns_servers="[$DNS_SERVERS]" \
+    -v network_name="$VCENTER_NETWORK_NAME" \
+    -v vcenter_dc="$VSPHERE_DATACENTER" \
+    -v vcenter_ds="$VCENTER_STORAGE_NAME" \
+    -v vcenter_ip="$VCENTER_IP" \
+    -v vcenter_user="$VCENTER_USERNAME" \
+    -v vcenter_password="$VCENTER_PASSWORD" \
+    -v vcenter_templates="$VCENTER_VM_TEMPLATES_FOLDER_NAME" \
+    -v vcenter_vms="$VCENTER_VMS_FOLDER_NAME" \
+    -v vcenter_disks="$VCENTER_DISK_FOLDER_NAME" \
+    -v vcenter_cluster="$VCENTER_CLUSTER_NAME" \
+    -v bosh_release_url="$BOSH_RELEASE_URL" \
+    -v bosh_release_sha="$BOSH_RELEASE_SHA" \
+    -v vsphere_cpi_release_url="$VSPHERE_CPI_URL" \
+    -v vsphere_cpi_release_sha="$VSPHERE_CPI_SHA" \
+    -v stemcell_url="$STEMCELL_URL" \
+    -v stemcell_sha="$STEMCELL_SHA" \
+    -v os_conf_release_url="$OS_CONF_RELEASE_URL" \
+    -v os_conf_release_sha="$OS_CONF_RELEASE_SHA" \
+    -v uaa_release_url="$UAA_RELEASE_URL" \
+    -v uaa_release_sha="$UAA_RELEASE_SHA" \
+    --var-file trusted_certs="$TRUSTED_CERT_FILE" \
+    $RESOURCE_POOL_OPS_FILE $RESOURCE_POOL_VARS \
+    $HTTP_PROXY_OPS_FILES $HTTP_PROXY_VARS
+
+# creates bosh env

--- a/scripts/bosh/bosh-deploy.sh
+++ b/scripts/bosh/bosh-deploy.sh
@@ -4,91 +4,16 @@ declare -r __DIR__="$( dirname "$( readlink -f "${BASH_SOURCE[0]}" )" )"
 
 source "$__DIR__"/../helpers
 source "$__DIR__"/../load-env
-source "$__DIR__"/../releases bosh uaa stemcell vsphere_cpi os_conf
 
+log "Deploying bosh"
 
-BOSH_DEPLOYMENT_DIRECTORY="$( git_submodule bosh-deployment )"
-
-HTTP_PROXY_OPS_FILES=" "
-HTTP_PROXY_VARS=" "
-if [ "$HTTP_PROXY_REQUIRED" = "true" ]; then
-  HTTP_PROXY_OPS_FILES=" -o $BOSH_DEPLOYMENT_DIRECTORY/misc/proxy.yml "
-  HTTP_PROXY_VARS=" -v http_proxy=$HTTP_PROXY \
-        -v https_proxy=$HTTPS_PROXY \
-        -v no_proxy=$NO_PROXY "
-fi
-
-RESOURCE_POOL_OPS_FILE=" "
-RESOURCE_POOL_VARS=" "
-if [ -n "$VCENTER_RESOURCE_POOL" ]; then
-  RESOURCE_POOL_OPS_FILE=" -o \"$BOSH_DEPLOYMENT_DIRECTORY\"/vsphere/resource-pool.yml"
-  RESOURCE_POOL_VARS=" -v vcenter_rp=\"$VCENTER_RESOURCE_POOL\""
-fi
-
-log "Creating bosh environment"
-$BOSH_CMD \
-  create-env "$BOSH_DEPLOYMENT_DIRECTORY"/bosh.yml \
-    --state="$ALIAS_DIRECTORY"/state.json \
-    --vars-store="$ALIAS_DIRECTORY"/creds.yml \
-    -o "$BOSH_DEPLOYMENT_DIRECTORY"/vsphere/cpi.yml \
-    -o "$BOSH_DEPLOYMENT_DIRECTORY"/jumpbox-user.yml \
-    -o "$BOSH_DEPLOYMENT_DIRECTORY"/uaa.yml \
-    -o "$__BASEDIR__"/ops-files/versions.yml \
-    -o "$__BASEDIR__"/ops-files/dns.yml \
-    -o "$__BASEDIR__"/ops-files/director-trusted-certs.yml \
-    -v director_name="$BOSH_ALIAS" \
-    -v internal_cidr="$NETWORK_CIDR" \
-    -v internal_gw="$NETWORK_GATEWAY" \
-    -v internal_ip="$BOSH_IP" \
-    -v dns_servers="[$DNS_SERVERS]" \
-    -v network_name="$VCENTER_NETWORK_NAME" \
-    -v vcenter_dc="$VSPHERE_DATACENTER" \
-    -v vcenter_ds="$VCENTER_STORAGE_NAME" \
-    -v vcenter_ip="$VCENTER_IP" \
-    -v vcenter_user="$VCENTER_USERNAME" \
-    -v vcenter_password="$VCENTER_PASSWORD" \
-    -v vcenter_templates="$VCENTER_VM_TEMPLATES_FOLDER_NAME" \
-    -v vcenter_vms="$VCENTER_VMS_FOLDER_NAME" \
-    -v vcenter_disks="$VCENTER_DISK_FOLDER_NAME" \
-    -v vcenter_cluster="$VCENTER_CLUSTER_NAME" \
-    -v bosh_release_url="$BOSH_RELEASE_URL" \
-    -v bosh_release_sha="$BOSH_RELEASE_SHA" \
-    -v vsphere_cpi_release_url="$VSPHERE_CPI_URL" \
-    -v vsphere_cpi_release_sha="$VSPHERE_CPI_SHA" \
-    -v stemcell_url="$STEMCELL_URL" \
-    -v stemcell_sha="$STEMCELL_SHA" \
-    -v os_conf_release_url="$OS_CONF_RELEASE_URL" \
-    -v os_conf_release_sha="$OS_CONF_RELEASE_SHA" \
-    -v uaa_release_url="$UAA_RELEASE_URL" \
-    -v uaa_release_sha="$UAA_RELEASE_SHA" \
-    --var-file trusted_certs="$TRUSTED_CERT_FILE" \
-    $RESOURCE_POOL_OPS_FILE $RESOURCE_POOL_VARS \
-    $HTTP_PROXY_OPS_FILES $HTTP_PROXY_VARS
+log "Calling bosh-create-env"
+"$__DIR__"/bosh-create-env.sh
 
 log "Logging into bosh"
 "$__DIR__"/bosh-login.sh
 
-RESOURCE_POOL_OPS_FILE=" "
-RESOURCE_POOL_VARS=" "
-if [ -n "$VCENTER_RESOURCE_POOL" ]; then
-  RESOURCE_POOL_OPS_FILE=" -o $__BASE_DIR__/ops-files/add-vcenter-resource-pool.yml"
-  RESOURCE_POOL_VARS=" -v vcenter_rp=\"$VCENTER_RESOURCE_POOL\""
-fi
-
-log "Updating the bosh cloud config"
-$BOSH_CMD -n \
-  -e "$BOSH_ALIAS" \
-  update-cloud-config "$__BASEDIR__"/cloud-configs/cloud-config.yml \
-    -v az_name="$CONCOURSE_AZ_NAME" \
-    -v nw_name="$CONCOURSE_NW_NAME" \
-    -v vcenter_cluster="$VCENTER_CLUSTER_NAME" \
-    -v network_cidr="$NETWORK_CIDR" \
-    -v network_name="$VCENTER_NETWORK_NAME" \
-    -v network_gateway="$NETWORK_GATEWAY" \
-    -v dns_servers="[$DNS_SERVERS]" \
-    -v reserved_ips="$RESERVED_IPS" \
-    -v static_ips="$CLOUD_CONFIG_STATIC_IPS" \
-    -v vm_disk_type="$VM_DISK_TYPE" \
-    $RESOURCE_POOL_OPS_FILE $RESOURCE_POOL_VARS
+log "Calling bosh-update-cloud-config"
+"$__DIR__"/bosh-update-cloud-config.sh
 
 # deploys bosh

--- a/scripts/bosh/bosh-update-cloud-config.sh
+++ b/scripts/bosh/bosh-update-cloud-config.sh
@@ -12,10 +12,15 @@ if [ -n "$VCENTER_RESOURCE_POOL" ]; then
   RESOURCE_POOL_VARS=" -v vcenter_rp=\"$VCENTER_RESOURCE_POOL\""
 fi
 
+CLOUD_CONFIG="$__BASEDIR__"/cloud-configs/cloud-config.yml
+if [ -z "$CUSTOM_CLOUD_CONFIG" ]; then
+    CLOUD_CONFIG="$CUSTOM_CLOUD_CONFIG"
+fi
+
 log "Updating the bosh cloud config"
 $BOSH_CMD -n \
   -e "$BOSH_ALIAS" \
-  update-cloud-config "$__BASEDIR__"/cloud-configs/cloud-config.yml \
+  update-cloud-config "$CLOUD_CONFIG" \
     -v az_name="$CONCOURSE_AZ_NAME" \
     -v nw_name="$CONCOURSE_NW_NAME" \
     -v vcenter_cluster="$VCENTER_CLUSTER_NAME" \

--- a/scripts/bosh/bosh-update-cloud-config.sh
+++ b/scripts/bosh/bosh-update-cloud-config.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -e
+
+declare -r __DIR__="$( dirname "$( readlink -f "${BASH_SOURCE[0]}" )" )"
+
+source "$__DIR__"/../helpers
+source "$__DIR__"/../load-env
+
+RESOURCE_POOL_OPS_FILE=" "
+RESOURCE_POOL_VARS=" "
+if [ -n "$VCENTER_RESOURCE_POOL" ]; then
+  RESOURCE_POOL_OPS_FILE=" -o $__BASE_DIR__/ops-files/add-vcenter-resource-pool.yml"
+  RESOURCE_POOL_VARS=" -v vcenter_rp=\"$VCENTER_RESOURCE_POOL\""
+fi
+
+log "Updating the bosh cloud config"
+$BOSH_CMD -n \
+  -e "$BOSH_ALIAS" \
+  update-cloud-config "$__BASEDIR__"/cloud-configs/cloud-config.yml \
+    -v az_name="$CONCOURSE_AZ_NAME" \
+    -v nw_name="$CONCOURSE_NW_NAME" \
+    -v vcenter_cluster="$VCENTER_CLUSTER_NAME" \
+    -v network_cidr="$NETWORK_CIDR" \
+    -v network_name="$VCENTER_NETWORK_NAME" \
+    -v network_gateway="$NETWORK_GATEWAY" \
+    -v dns_servers="[$DNS_SERVERS]" \
+    -v reserved_ips="$RESERVED_IPS" \
+    -v static_ips="$CLOUD_CONFIG_STATIC_IPS" \
+    -v vm_disk_type="$VM_DISK_TYPE" \
+    $RESOURCE_POOL_OPS_FILE $RESOURCE_POOL_VARS
+
+# uploads bosh cloud-config

--- a/scripts/env-template
+++ b/scripts/env-template
@@ -35,6 +35,12 @@ export CONCOURSE_RELEASES_LATEST=true
 ##
 
 ###
+# Sets a config server for bosh to generate secrets and store internally
+##
+# CONFIG_SERVER=credhub
+##
+
+###
 # The repositories to pull code from.  These will be placed in the `VENDOR_DIRECTORY` and pulled each time they are needed.
 ##
 export BOSH_DEPLOYMENT_REPOSITORY=https://github.com/cloudfoundry/bosh-deployment

--- a/scripts/env-template
+++ b/scripts/env-template
@@ -37,7 +37,13 @@ export CONCOURSE_RELEASES_LATEST=true
 ###
 # Sets a config server for bosh to generate secrets and store internally
 ##
-# CONFIG_SERVER=credhub
+# export CONFIG_SERVER=credhub
+##
+
+###
+# Allows a different cloud config to be used
+##
+# export CUSTOM_CLOUD_CONFIG=
 ##
 
 ###

--- a/scripts/helpers
+++ b/scripts/helpers
@@ -53,7 +53,16 @@ function log() {
   echo -e "[\e[93m$( date +"$_date_format" )\e[39m][\e[32m$_caller\e[39m] $@" >&2 2> >( tee -a "$_logfile" )
 }
 
-
+###
+# Clones a repository and checks out onto a particular branch if specified.
+#
+# Environment:
+#   {name^^}_REPOSITORY {uri} The repository to clone
+#   {name^^}_VERSION {uri} The version/branch to checkout onto
+#
+# Parameters:
+#   1 (name) {string} The prefix for variable names
+##
 function git_submodule() {
   local _name="$1"
   local _NAME="$( uppercase "${_name/-/_}" )"

--- a/scripts/load-env
+++ b/scripts/load-env
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eo pipefail
+set -exo pipefail
 
 source "$( dirname "$( readlink -f "${BASH_SOURCE[0]}" )" )"/helpers
 
@@ -58,9 +58,39 @@ export http_proxy=$HTTP_PROXY
 export https_proxy=$HTTPS_PROXY
 
 if [ "$HTTP_PROXY_REQUIRED" = "true" ]; then
-  printf -v NO_PROXY '%s,' $( eval echo $NO_PROXY_PATTERN )
-  export NO_PROXY
-  export no_proxy=$NO_PROXY
+  # Backwards compatability
+  if [ -n "$NO_PROXY_PATTERN" ]; then
+    log "The NO_PROXY_PATTERN variable is to be deprecated.  Please use the NO_PROXY variable as an nmap range"
+    printf -v _no_proxy '%s,' $( eval echo $NO_PROXY_PATTERN )
+  fi
+
+  # Split the string by commas
+  NO_PROXY=${NO_PROXY//,/ }
+
+  for i in $NO_PROXY; do
+    j="$i"
+    _j="$( nmap -sL -n $NO_PROXY $_NO_PROXY )"
+    if echo "$_j" | grep -vq 'Failed to resolve'; then
+      log "Expanding IP Range: $i"
+      j="$( echo "$_j" | grep 'Nmap scan report for' | cut -f 5 -d ' ' | tr '\n' ',' )"
+    fi
+
+    _no_proxy="$_no_proxy,$j"
+  done
+
+  # ltrim ,
+  if [ "${_no_proxy:0:1}" = "," ]; then
+    _no_proxy="${_no_proxy:1}"
+  fi
+
+  # rtrim ,
+  len=${#_no_proxy}
+  if [ "${_no_proxy:$((len-1))}" = "," ]; then
+    _no_proxy="${_no_proxy::$((len-1))}"
+  fi
+
+  export NO_PROXY=$_no_proxy
+  export no_proxy=$_no_proxy
 fi
 
 declare -r ENV_LOADED=


### PR DESCRIPTION
* Separates bosh `create-env` and `upload-cloud-config`
* Allows custom cloud config to be provided to bosh
* Uses nmap to expand ip ranges instead of BASH expansion to allow for a more configurable `no_proxy`
* Allows the credhub credential manager job to be added to bosh director