### PR TITLE
A few bugfixes

### DIFF
--- a/scripts/bosh/bosh-create-env.sh
+++ b/scripts/bosh/bosh-create-env.sh
@@ -28,7 +28,7 @@ CONFIG_SERVER_OPS_FILE=" "
 CONFIG_SERVER_VARS=" "
 if [ -n "$CONFIG_SERVER" ]; then
   if [ "$CONFIG_SERVER" = "credhub" ]; then
-    CONFIG_SERVER_OPS_FILE=" -o \"$BOSH_DEPLOYMENT_DIRECTORY\"/credhub.yml"
+    CONFIG_SERVER_OPS_FILE=" -o $BOSH_DEPLOYMENT_DIRECTORY/credhub.yml"
     CONFIG_SERVER_VARS=" "
   else
     log "Unknown config server configuration"

--- a/scripts/load-env
+++ b/scripts/load-env
@@ -30,10 +30,10 @@ declare -r __BASEDIR__="$( cd "$__DIR/.." && pwd )"
 
 declare -r ENV_DIRECTORY="${ENV_DIRECTORY:-$__DIR}"
 
-export BOSH_CMD=bosh
-export VAULT_CMD=vault
-export JQ_CMD=jq
-export CREDHUB_CMD=credhub
+export BOSH_CMD="${BOSH_CMD:-bosh}"
+export VAULT_CMD="${VAULT_CMD:-vault}"
+export JQ_CMD="${JQ_CMD:-jq}"
+export CREDHUB_CMD="${CREDHUB_CMD:-credhub}"
 
 if [ -n "$ENV" ]; then
   log "sourcing $ENV_DIRECTORY/$ENV-env...."

--- a/scripts/load-env
+++ b/scripts/load-env
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -exo pipefail
+set -eo pipefail
 
 source "$( dirname "$( readlink -f "${BASH_SOURCE[0]}" )" )"/helpers
 

--- a/scripts/load-env
+++ b/scripts/load-env
@@ -69,10 +69,12 @@ if [ "$HTTP_PROXY_REQUIRED" = "true" ]; then
 
   for i in $NO_PROXY; do
     j="$i"
-    _j="$( nmap -sL -n $NO_PROXY $_NO_PROXY )"
-    if echo "$_j" | grep -vq 'Failed to resolve'; then
+    _j="$( nmap -sL -n $i 2>&1 )"
+    if [ -n "${_j##*Failed to resolve*}" ]; then
       log "Expanding IP Range: $i"
       j="$( echo "$_j" | grep 'Nmap scan report for' | cut -f 5 -d ' ' | tr '\n' ',' )"
+    else
+      log "Skipping expansion of $i"
     fi
 
     _no_proxy="$_no_proxy,$j"

--- a/scripts/vault/vault-deploy.sh
+++ b/scripts/vault/vault-deploy.sh
@@ -59,6 +59,7 @@ if [ "$( $VAULT_CMD secrets list -format=json | $JQ_CMD -r "has(\"$_MOUNT\")" )"
 fi
 
 function _create_token() {
+  echo "Creating token"
   $VAULT_CMD token create --policy="$VAULT_POLICY_NAME" -period="87600h" -format=json > "$VAULT_TOKEN_FILE"
 }
 

--- a/scripts/vault/vault-helpers
+++ b/scripts/vault/vault-helpers
@@ -15,6 +15,10 @@ done <<< "$( grep '^Unseal Key' "$VAULT_LOG" )"
 export VAULT_UNSEAL_KEYS="${_VAULT_UNSEAL_KEYS[@]}"
 
 function get_client_token() {
+  if [ -f "$VAULT_TOKEN_FILE" ]; then
+    return 1
+  fi
+
   cat "$VAULT_TOKEN_FILE" | $JQ_CMD -r .auth.client_token
   return $?
 }


### PR DESCRIPTION
* Quotations within the string caused issues
* Removed `-x` from `load-env`
* Check if the token file exists prior
* All commands are configurable again
